### PR TITLE
Update DataLoader.swift

### DIFF
--- a/Source/DataLoader.swift
+++ b/Source/DataLoader.swift
@@ -33,6 +33,7 @@ open class DataLoader: Nuke.DataLoading {
                     } else {
                         reject(error ?? NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil))
                     }
+                    finish()
                 }
                 token?.register {
                     task.cancel()


### PR DESCRIPTION
Swift3 version needs finish() call injected into Alamofire manager response callback (to fulfil promise()). Without this, a first set of requests will succeed but Promise will stop scheduling then everything halts.
